### PR TITLE
VARSITY-141 - Return athlete stats or team athlete stats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { ApolloServer } from "@apollo/server";
 import { startStandaloneServer } from "@apollo/server/standalone";
 import { addMocksToSchema } from "@graphql-tools/mock";
 import { makeExecutableSchema } from "@graphql-tools/schema";
+import resolvers from "./resolvers.js";
 
 const typeDefs = `#graphql
 scalar DateTime
@@ -16,6 +17,11 @@ type Query {
   getSoccerStats: SoccerStats
   getVolleyballStats: VolleyballStats
   team: Team!
+  getAthlete(id: ID): Athlete
+  teamAthlete: TeamAthlete!
+  footballPassingStats: FootballPassingStats
+  getTeamAthlete(id: ID): TeamAthlete
+  athlete: Athlete!
 }
 
 union Organization =
@@ -117,6 +123,8 @@ type TeamAthlete {
   jerseyNumber: String
   grade: Int
   season: SportSeason!
+  footballPassingStats: FootballPassingStats
+  footballStats: [FootballStats]
 }
 
 type Athlete {
@@ -126,6 +134,7 @@ type Athlete {
   middleName: String
   photo: String!
   nickNames: [String!]!
+  athleteOnTeams: [TeamAthlete]
 }
 
 type School {
@@ -406,6 +415,8 @@ type FootballTeamStats {
     penalties: Int
     penaltyYards: Int
 }
+
+union FootballStats = FootballPassingStats | FootballRushingStats | FootballReceivingStats
 
 type FootballPassingStats {
     gamesPlayed: Int
@@ -810,17 +821,11 @@ type GeneralStats {
 // Just need to pass resolvers in with typeDefs when that's ready
 const server = new ApolloServer({
   schema: addMocksToSchema({
-    schema: makeExecutableSchema({ typeDefs }),
+    schema: makeExecutableSchema({ typeDefs, resolvers }),
+    preserveResolvers: true,
   }),
 });
 
-// const resolvers = {
-//     Query: {
-//         getTeamsForSport: () => {
-//             return
-//         }
-//     }
-// }
 
 const { url } = await startStandaloneServer(server, { listen: { port: 4000 } });
 

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -1,0 +1,70 @@
+const resolvers = {
+  Query: {
+    teamAthlete: (parent, args, content, info) => {
+      return {
+        footballPassingStats: loadFootballPassingStats(),
+      };
+    },
+
+    footballPassingStats: (parent, args, content, info) => {
+      return loadFootballPassingStats();
+    },
+  },
+  TeamAthlete: {
+    footballPassingStats: () => {
+      return loadFootballPassingStats();
+    },
+    footballStats: () => {
+      return loadFootballStats();
+    },
+  },
+
+  // FootballPassingStats | FootballRushingStats | FootballReceivingStats
+  FootballStats: {
+    __resolveType(obj, context, info) {
+      if (obj.passing_stats) {
+        return "FootballPassingStats";
+      }
+      if (obj.fumbles) {
+        return "FootballRushingStats";
+      }
+      if (obj.receptions) {
+        return "FootballReceivingStats";
+      }
+      return "FootballPassingStats"; // Type resolution failed
+    },
+  },
+};
+
+const loadFootballPassingStats = () => {
+  return {
+    passing_stats: true,
+    attempted: 111,
+    completed: 15,
+  };
+};
+
+const loadFootballStats = () => {
+  return [
+    {
+      passing_stats: true,
+      attempted: 111,
+      completed: 15,
+      fumbles: 3,
+    },
+    {
+      rushing_stats: true,
+      attemptedYards: 11,
+      touchdowns: 5,
+      fumbles: 3,
+    },
+    {
+      recieving_stats: true,
+      targets: 31,
+      receptions: 15,
+      twoPointConv: 3,
+    },
+  ];
+};
+
+export default resolvers;


### PR DESCRIPTION
In response to [VARSITY-141](https://minneapolisstartribune.atlassian.net/browse/VARSITY-141)   I have created a couple ways to get football stats through GraphQL queries.


I've introduced a new union for quarterback stats:
`union FootballStats = FootballPassingStats | FootballRushingStats | FootballReceivingStats`

There are two different types of queries: 

- based on Athlete
- based on TeamAthlete

Sports Engine statistics are based on the `TeamAthlete` (in SE terminology a roster athlete on a particular team instance during this subseason), so maybe that is the kind of query we want to use at first.


### TeamAthlete

Here I have added an `id` field to the `TeamAthlete`, so we can use it in a `getTeamAthlete($id)` query.

We can split on the fragments and get whatever type of stats data which might be available for this (team)athlete.

```graphql
query GetTeamAthlete($getTeamAthleteId: ID) {
  getTeamAthlete(id: $getTeamAthleteId) {
    id
    athlete {
      id
      lastName
    }
    footballStats {
      __typename
      ... on FootballPassingStats {
        attempted
        averageYards
        completed
        interceptions
        sacks
      }
      ... on FootballRushingStats {
        attemptedYards
        averageYards
        fumbles
        touchdowns
        totalYards
      }
      ... on FootballReceivingStats {
        receptions
        averageYards
        touchdowns
        twoPointConv
        targets
      }
    }
  }
}
```

In this branch's code I have constructed a sample set of football stats data and rigged the ApolloServer to fill in other fields with mock data. 
I added some flags like passing_stats to indicate which stat category. After we get some data from the data source we can add the flags to help the resolver make sense of what to do. Will this be helpful?

```javascript
[
    {
      passing_stats: true,
      attempted: 111,
      completed: 15,
      sacks: 3,
    },
    {
      rushing_stats: true,
      attemptedYards: 11,
      touchdowns: 5,
      fumbles: 3,
    },
    {
      recieving_stats: true,
      targets: 31,
      receptions: 15,
      twoPointConv: 3,
    },
  ]
```


### Athlete
In this query, we start with an athlete id, and then the field I called `athleteOnTeams` will enumerate all of the teams that contain some `footballPassingStats`:

```graphql
query Query($getAthleteId: ID) {
  getAthlete(id: $getAthleteId) {
    id
    lastName
    athleteOnTeams {
      footballPassingStats {
        attempted
        averageYards
        completed
      }
    }
  }
}
```

